### PR TITLE
Fix weather_api to use external APIs

### DIFF
--- a/forecaster/weather_api.go
+++ b/forecaster/weather_api.go
@@ -33,7 +33,19 @@ func NewAPIClient(baseURL string, apiKey string) APIClient {
 
 // GetDailyForecast fetches the daily forecast from the third-party weather API service.
 func (c APIClient) GetDailyForecast(lat float64, lon float64, dateOffset int) (APIClientResponse, error) {
-	url := fmt.Sprintf("%s/forecast/daily?lat=%f&lon=%f&days_later=%d&api_key=%s", c.baseURL, lat, lon, dateOffset, c.apiKey)
+	if lat < -90 || lat >= 90 {
+		return APIClientResponse{}, fmt.Errorf("lat(%f) is invalid", lat)
+	}
+
+	if lon < -180 || lon >= 180 {
+		return APIClientResponse{}, fmt.Errorf("lon(%f) is invalid", lon)
+	}
+
+	if dateOffset < 0 || dateOffset > 10 {
+		return APIClientResponse{}, fmt.Errorf("dateOffset(%d) is invalid", dateOffset)
+	}
+
+	url := fmt.Sprintf("%s/forecast/daily?lat=%f&lon=%f&date_offset=%d&api_key=%s", c.baseURL, lat, lon, dateOffset, c.apiKey)
 	resp, err := http.Get(url)
 	if err != nil {
 		return APIClientResponse{}, err

--- a/forecaster/weather_api.go
+++ b/forecaster/weather_api.go
@@ -1,5 +1,12 @@
 package main
 
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
 type APIClientResponse struct {
 	Timestamp int64   `json:"timestamp"`
 	Code      int     `json:"code"`
@@ -26,5 +33,24 @@ func NewAPIClient(baseURL string, apiKey string) APIClient {
 
 // GetDailyForecast fetches the daily forecast from the third-party weather API service.
 func (c APIClient) GetDailyForecast(lat float64, lon float64, dateOffset int) (APIClientResponse, error) {
-	return APIClientResponse{}, nil
+	url := fmt.Sprintf("%s/forecast/daily?lat=%f&lon=%f&days_later=%d&api_key=%s", c.baseURL, lat, lon, dateOffset, c.apiKey)
+	resp, err := http.Get(url)
+	if err != nil {
+		return APIClientResponse{}, err
+	}
+
+	defer resp.Body.Close()
+
+	res, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return APIClientResponse{}, err
+	}
+
+	var acr APIClientResponse
+	err = json.Unmarshal(res, &acr)
+	if err != nil {
+		return APIClientResponse{}, err
+	}
+
+	return acr, nil
 }


### PR DESCRIPTION
As-Is
- weather API가 third-party API 를 사용하지 않고 empty response를 주고 있었습니다.
- testcase에 valid case만 존재하여 invalid paramter에 대한 체크를 하지 않았습니다.

To-be
- weather API가 정상적으로 third-party API를 사용하여 logical하게 response를 반환합니다.
- testcase에 invalid case를 추가했습니다.
- API호출 전에 parameter를 점검합니다. 이는 API time delay가 500ms이므로 미리 사전 점검을 통해 성능을 향상시키기 위함입니다.