### PR TITLE
Fix buddy to return message based on weathersvc

### DIFF
--- a/buddy/main.go
+++ b/buddy/main.go
@@ -1,7 +1,70 @@
 package main
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/kdy6921/weathersvc/buddy/utils"
+)
 
 func main() {
-	fmt.Println("안녕하세요. 오늘 날씨는 맑습니다!")
+	pos := utils.GetCurrentGeoPosition()
+	resp, err := http.Get(fmt.Sprintf("http://localhost:8080/weekly?lat=%f&lon=%f", pos.Latitude, pos.Longitude))
+	if err != nil {
+		log.Fatal("API is broken")
+	}
+	defer resp.Body.Close()
+
+	res, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal("Response is broken")
+	}
+
+	var fr utils.ForecastResponse
+	err = json.Unmarshal(res, &fr)
+	if err != nil {
+		return
+	}
+	var vo utils.VO
+	for _, v := range fr.Forecasts {
+		t, err := time.Parse("2006-01-02", v.Date)
+		if err != nil {
+			return
+		}
+		tmp := utils.Forecast{
+			t.Unix(),
+			v.Weather,
+			v.Temperature.Min,
+			v.Temperature.Max,
+			v.Rain,
+		}
+		vo.Forecasts = append(vo.Forecasts, tmp)
+	}
+	vo.Sort()
+
+	if vo.IsRainyTomorrow() {
+		fmt.Print("내일은 비가 내릴 예정입니다!")
+		return
+	}
+
+	if vo.IsThreeDaysRainy() {
+		fmt.Print("이번주 내내 비 소식이 있어요.")
+		return
+	}
+
+	if vo.IsThreeDaysRainy() {
+		fmt.Print("날씨가 약간은 칙칙해요")
+		return
+	}
+
+	if vo.IsThreeDaysRainy() {
+		fmt.Print("일주일 내내 날씨가 맑아요!")
+		return
+	}
+
+	fmt.Print("맑은 날씨를 즐기세요.")
 }

--- a/buddy/main.go
+++ b/buddy/main.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/kdy6921/weathersvc/buddy/utils"
+	"buddy/utils"
 )
 
 func main() {
@@ -36,35 +36,35 @@ func main() {
 			return
 		}
 		tmp := utils.Forecast{
-			t.Unix(),
-			v.Weather,
-			v.Temperature.Min,
-			v.Temperature.Max,
-			v.Rain,
+			Date:    t.Unix(),
+			Weather: v.Weather,
+			Min:     v.Temperature.Min,
+			Max:     v.Temperature.Max,
+			Rain:    v.Rain,
 		}
 		vo.Forecasts = append(vo.Forecasts, tmp)
 	}
 	vo.Sort()
 
 	if vo.IsRainyTomorrow() {
-		fmt.Print("내일은 비가 내릴 예정입니다!")
+		fmt.Print("내일은 비가 내릴 예정입니다!\n")
 		return
 	}
 
 	if vo.IsThreeDaysRainy() {
-		fmt.Print("이번주 내내 비 소식이 있어요.")
+		fmt.Print("이번주 내내 비 소식이 있어요.\n")
 		return
 	}
 
-	if vo.IsThreeDaysRainy() {
-		fmt.Print("날씨가 약간은 칙칙해요")
+	if vo.IsThreeDaysCloudy() {
+		fmt.Print("날씨가 약간은 칙칙해요\n")
 		return
 	}
 
-	if vo.IsThreeDaysRainy() {
-		fmt.Print("일주일 내내 날씨가 맑아요!")
+	if vo.IsFiveDaysSunny() {
+		fmt.Print("일주일 내내 날씨가 맑아요!\n")
 		return
 	}
 
-	fmt.Print("맑은 날씨를 즐기세요.")
+	fmt.Print("맑은 날씨를 즐기세요.\n")
 }

--- a/buddy/utils/geo.go
+++ b/buddy/utils/geo.go
@@ -1,4 +1,4 @@
-package main
+package utils
 
 import (
 	"math/rand"

--- a/buddy/utils/model.go
+++ b/buddy/utils/model.go
@@ -1,0 +1,77 @@
+package model
+
+import (
+	"sort"
+)
+
+type ForecastResponse struct {
+	Forecasts []struct {
+		Date        string `json:"date"`
+		Weather     string `json:"weather"`
+		Temperature struct {
+			Min int `json:"min"`
+			Max int `json:"max"`
+		} `json:"temperature"`
+		Rain int `json:"rain"`
+	} `json:"forecasts"`
+}
+
+type VO struct {
+	Forecasts []Forecast
+}
+
+type Forecast struct {
+	Date    int64
+	Weather string
+	Min     int
+	Max     int
+	Rain    int
+}
+
+type Alarm interface {
+	IsRainyTomorrow() bool
+	IsThreeDaysRainy() bool
+	IsThreeDaysCloudy() bool
+	IsFiveDaysSunny() bool
+	Sort()
+}
+
+func (v *VO) Sort() {
+	sort.Slice(v.Forecasts, func(i, j int) bool {
+		return v.Forecasts[i].Date < v.Forecasts[j].Date
+	})
+}
+
+func (v *VO) IsRainyTomorrow() bool {
+	return v.Forecasts[0].Weather == "rainy"
+}
+
+func (v *VO) IsThreeDaysRainy() bool {
+	count := 0
+	for _, forecast := range v.Forecasts {
+		if forecast.Weather == "rainy" {
+			count++
+		}
+	}
+	return count >= 3
+}
+
+func (v *VO) IsThreeDaysCloudy() bool {
+	count := 0
+	for _, forecast := range v.Forecasts {
+		if forecast.Weather == "cloudy" {
+			count++
+		}
+	}
+	return count >= 3
+}
+
+func (v *VO) IsFiveDaysSunny() bool {
+	count := 0
+	for _, forecast := range v.Forecasts {
+		if forecast.Weather == "clear" {
+			count++
+		}
+	}
+	return count >= 5
+}

--- a/buddy/utils/model.go
+++ b/buddy/utils/model.go
@@ -1,4 +1,4 @@
-package model
+package utils
 
 import (
 	"sort"


### PR DESCRIPTION
As-Is
- 구현이 없이 항상 sunny case만 반환

To-Be
- weather API를 사용하여 로직에 맞게 반환
- directory 구조를 변경하여 `main.go`만 실행하여 결과를 알 수 있도록 변경
