### PR TITLE
Sort the API results, with query creator

### DIFF
--- a/buddy/main.go
+++ b/buddy/main.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"time"
 
@@ -13,13 +14,23 @@ import (
 )
 
 var (
-	host = os.Getenv("API_HOST")
+	host    = os.Getenv("API_HOST")
+	apiPath = "weekly"
 )
 
 func main() {
 	pos := utils.GetCurrentGeoPosition()
-	resp, err := http.Get(fmt.Sprintf("%s/weekly?lat=%f&lon=%f", host, pos.Latitude, pos.Longitude))
-	fmt.Println(host)
+	u, err := url.Parse(host)
+	if err != nil {
+		log.Fatal("host is invalid")
+	}
+	u.Path = apiPath
+	q := u.Query()
+	q.Set("lat", fmt.Sprint(pos.Latitude))
+	q.Set("lon", fmt.Sprint(pos.Longitude))
+	u.RawQuery = q.Encode()
+
+	resp, err := http.Get(u.String())
 	if err != nil {
 		log.Fatal("API is broken")
 	}
@@ -50,7 +61,6 @@ func main() {
 		}
 		vo.Forecasts = append(vo.Forecasts, tmp)
 	}
-	vo.Sort()
 
 	if vo.IsRainyTomorrow() {
 		fmt.Print("내일은 비가 내릴 예정입니다!\n")

--- a/buddy/main.go
+++ b/buddy/main.go
@@ -6,14 +6,20 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"time"
 
 	"buddy/utils"
 )
 
+var (
+	host = os.Getenv("API_HOST")
+)
+
 func main() {
 	pos := utils.GetCurrentGeoPosition()
-	resp, err := http.Get(fmt.Sprintf("http://localhost:8080/weekly?lat=%f&lon=%f", pos.Latitude, pos.Longitude))
+	resp, err := http.Get(fmt.Sprintf("%s/weekly?lat=%f&lon=%f", host, pos.Latitude, pos.Longitude))
+	fmt.Println(host)
 	if err != nil {
 		log.Fatal("API is broken")
 	}

--- a/buddy/utils/model.go
+++ b/buddy/utils/model.go
@@ -1,9 +1,5 @@
 package utils
 
-import (
-	"sort"
-)
-
 type ForecastResponse struct {
 	Forecasts []struct {
 		Date        string `json:"date"`
@@ -33,13 +29,6 @@ type Alarm interface {
 	IsThreeDaysRainy() bool
 	IsThreeDaysCloudy() bool
 	IsFiveDaysSunny() bool
-	Sort()
-}
-
-func (v *VO) Sort() {
-	sort.Slice(v.Forecasts, func(i, j int) bool {
-		return v.Forecasts[i].Date < v.Forecasts[j].Date
-	})
 }
 
 func (v *VO) IsRainyTomorrow() bool {

--- a/forecaster/run.sh
+++ b/forecaster/run.sh
@@ -1,0 +1,6 @@
+export API_URL=https://thirdparty-weather-api.droom.workers.dev/
+export API_KEY=AGHANFFFLLURRYKRJFR5V
+export HOST=localhost
+export PORT=8080
+
+go build && ./forecaster

--- a/forecaster/weather_api.go
+++ b/forecaster/weather_api.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 )
 
 type APIClientResponse struct {
@@ -26,6 +27,8 @@ type APIClient struct {
 	apiKey  string
 }
 
+var apiPath = "forecast/daily"
+
 // NewAPIClient creates a new APIClient
 func NewAPIClient(baseURL string, apiKey string) APIClient {
 	return APIClient{baseURL: baseURL, apiKey: apiKey}
@@ -45,8 +48,19 @@ func (c APIClient) GetDailyForecast(lat float64, lon float64, dateOffset int) (A
 		return APIClientResponse{}, fmt.Errorf("dateOffset(%d) is invalid", dateOffset)
 	}
 
-	url := fmt.Sprintf("%s/forecast/daily?lat=%f&lon=%f&date_offset=%d&api_key=%s", c.baseURL, lat, lon, dateOffset, c.apiKey)
-	resp, err := http.Get(url)
+	u, err := url.Parse(c.baseURL)
+	if err != nil {
+		return APIClientResponse{}, err
+	}
+	u.Path = apiPath
+	q := u.Query()
+	q.Set("lat", fmt.Sprint(lat))
+	q.Set("lon", fmt.Sprint(lon))
+	q.Set("date_offset", fmt.Sprint(dateOffset))
+	q.Set("api_key", c.apiKey)
+	u.RawQuery = q.Encode()
+
+	resp, err := http.Get(u.String())
 	if err != nil {
 		return APIClientResponse{}, err
 	}


### PR DESCRIPTION
As-Is
1. timeout에 대한 명세가 없었습니다.
2. quick & dirty하게 url을 생성하였습니다.
3. 실행에 대한 스크립트가 존재하지 않았습니다.

To-Be
1. timeouts를 구현하여 2초 내에 응답이 없을 시에 500 error를 반환합니다.
2. `net/url`을 사용하여 url을 build합니다.
3. `forecaster`에 실행용 스크립트를 추가했습니다.